### PR TITLE
Clean up docs, naming

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -59,5 +59,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v2
         with:
-          name: jupyterlab_webrtc_docprovider-releaser-dist-${{ github.run_number }}
+          name: jupyterlab-webrtc-docprovider-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0
+
+- initial release
+
 <!-- <START NEW CHANGELOG ENTRY> -->
 
 <!-- <END NEW CHANGELOG ENTRY> -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ is installed with JupyterLab.
 
 ```bash
 # Clone the repo to your local environment
-# Change directory to the jupyterlab_webrtc_docprovider directory
+# Change directory to the jupyterlab-webrtc-docprovider directory
 # Install package in development mode
 python -m pip install -e .
 # Link your development version of the extension with JupyterLab
@@ -44,7 +44,7 @@ jupyter lab build --minimize=False
 ## Development uninstall
 
 ```bash
-pip uninstall jupyterlab_webrtc_docprovider
+pip uninstall jupyterlab-webrtc-docprovider
 ```
 
 In development mode, you will also need to remove the symlink created by

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
   - optionally provide `username` and `usercolor`
     - e.g. `http://localhost:8888/lab?room=demo&username=jo&usercolor=e65100`
   - these parameters will probably be consumed, but _that's okay_
-- Open a shared editing activity like a _Notebook_ or _Editor_
+- Open a shared editing activity like _Notebook_ or _Editor_
 
 ## Install
 
-To install the extension, execute:
+To install the extension, run:
 
 ```bash
 pip install jupyterlab_webrtc_docprovider
@@ -45,8 +45,7 @@ Unlike JupyterLab's built-in, purely WebSocket-based [collaborative] document pr
 
 ### Server Configuration
 
-The `collaborative` high level flag `jupyter_server_config.json` must be enabled like
-this:
+Jupyter Server is configured with `jupyter_server_config.json`:
 
 ```json
 {
@@ -59,6 +58,9 @@ this:
 #### `collaborative`
 
 This flag must be enabled for the provider to be used.
+
+> In JupyterLite, this is a configurable of `jupyter-config-data` in
+> `jupyter-lite.json`.
 
 ### Client Configuration
 
@@ -83,6 +85,8 @@ User-configurable settings can be pre-populated in
 }
 ```
 
+> In JupyterLite, this can be configured with an `overrides.json`
+
 #### `roomPrefix`
 
 By default, the final room ID that is actually sent to the signaling server will be the
@@ -96,10 +100,11 @@ By default this prefix is the domain serving the site, but for common URLs (like
 By default, a number of public signaling servers are provided, as described by
 [y-webrtc], as shown above.
 
-> **Note** While the content of your exchange is strictly peer-to-peer, and the above
-> are suitable for demos like binder.
+> **Note**: the signaling server, as the name suggests, should only know high-level
+> metadata about your exchange, and should be protected from third-parties by standard
+> SSL encryption.
 >
-> A real production deployment should **not** rely on free hosted services at runtime.
+> However, a real deployment should **not** rely on free hosted services at runtime.
 > Some research would be required to find an appropriate server for your specific
 > deployment.
 
@@ -109,8 +114,8 @@ The name displayed to others next to your cursor in shared editing sessions.
 
 #### `usercolor`
 
-A suggested color for the cursor displayed to others next to your cursor in shared
-editing sessions.
+A suggested color of your cursor, as displayed to others next in shared editing
+sessions.
 
 ## Uninstall
 
@@ -127,8 +132,9 @@ This work is licensed under the [BSD 3-Clause License][license].
 The code was originally extracted from [JupyterLite] and [JupyterLab], which are also
 covered under the BSD 3-Clause License.
 
-Two vendored patches are applied to [simple-peer](https://github.com/feross/simple-peer)
-and [int64-buffer](https://github.com/kawanet/int64-buffer), both of which are licensed
+Two vendored patches (special thanks to [@datakurre]) are applied to
+[simple-peer](https://github.com/feross/simple-peer) and
+[int64-buffer](https://github.com/kawanet/int64-buffer), both of which are licensed
 under the MIT license, and should hopefully be merged some day.
 
 [webrtc]:
@@ -145,3 +151,4 @@ under the MIT license, and should hopefully be merged some day.
 [lumino]: https://github.com/jupyterlab/lumino
 [contributing guide]:
   https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/blob/main/CONTRIBUTING.md
+[@datakurre]: https://github.com/datakurre/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# jupyterlab_webrtc_docprovider
+# jupyterlab-webrtc-docprovider
 
-[![Github Actions Status](https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/workflows/Build/badge.svg)](https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlite/jupyterlab-webrtc-docprovider/main?urlpath=lab)
+[![install from PyPI][pypi-badge]][pypi] [![demo on Binder][binder-badge]][binder]
+[![GitHub Actions][ci-badge]][ci]
 
 > Document collaboration for [JupyterLab], powered by [y-webrtc].
 
@@ -28,7 +29,7 @@
 To install the extension, run:
 
 ```bash
-pip install jupyterlab_webrtc_docprovider
+pip install jupyterlab-webrtc-docprovider
 ```
 
 > For a development install, see the [contributing guide].
@@ -36,7 +37,7 @@ pip install jupyterlab_webrtc_docprovider
 ## How it Works
 
 Unlike JupyterLab's built-in, purely WebSocket-based [collaborative] document provider,
-`jupyterlab_webrtc_docprovider` relies on:
+`jupyterlab-webrtc-docprovider` relies on:
 
 - an initialing [signaling server] to locate peers
 - the [WebRTC] protocol to coordinate actual data exchange
@@ -152,3 +153,12 @@ under the MIT license, and should hopefully be merged some day.
 [contributing guide]:
   https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/blob/main/CONTRIBUTING.md
 [@datakurre]: https://github.com/datakurre/
+[binder]:
+  https://mybinder.org/v2/gh/jupyterlite/jupyterlab-webrtc-docprovider/main?urlpath=lab
+[binder-badge]: https://mybinder.org/badge_logo.svg
+[ci-badge]:
+  https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/workflows/Build/badge.svg
+[ci]:
+  https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/actions/workflows/build.yml
+[pypi]: https://pypi.org/project/jupyterlab-webrtc-docprovider
+[pypi-badge]: https://img.shields.io/pypi/v/jupyterlab-webrtc-docprovider

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Making a new release of jupyterlab_webrtc_docprovider
+# Making a new release of jupyterlab-webrtc-docprovider
 
 The extension can be published to `PyPI` and `npm` manually or using the
 [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" perform a development install of jupyterlab_webrtc_docprovider
+""" perform a development install of jupyterlab-webrtc-docprovider
 
     On Binder, this will run _after_ the environment has been fully created from
     the environment.yml in this directory.
@@ -53,5 +53,5 @@ for conf in ["jupyter_config.json"]:
 SETTINGS.mkdir(parents=True, exist_ok=True)
 (SETTINGS / "overrides.json").write_bytes((BINDER / "overrides.json").read_bytes())
 
-print("JupyterLab with jupyterlab_webrtc_docprovider is ready to run with:\n")
+print("JupyterLab with jupyterlab-webrtc-docprovider is ready to run with:\n")
 print("\tjupyter lab\n")

--- a/install.json
+++ b/install.json
@@ -1,5 +1,5 @@
 {
   "packageManager": "python",
-  "packageName": "jupyterlab_webrtc_docprovider",
-  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_webrtc_docprovider"
+  "packageName": "jupyterlab-webrtc-docprovider",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab-webrtc-docprovider"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,18 @@
 [build-system]
-requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+requires = [
+    "jupyter_packaging>=0.10,<1",
+    "jupyterlab>=3.1,<4",
+]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.options]
-skip-if-exists = ["jupyterlab_webrtc_docprovider/labextension/static/style.js"]
-ensured-targets = ["jupyterlab_webrtc_docprovider/labextension/static/style.js", "jupyterlab_webrtc_docprovider/labextension/package.json"]
+skip-if-exists = [
+    "jupyterlab_webrtc_docprovider/labextension/static/style.js",
+]
+ensured-targets = [
+    "jupyterlab_webrtc_docprovider/labextension/package.json",
+    "jupyterlab_webrtc_docprovider/labextension/static/style.js",
+]
 
 [tool.jupyter-packaging.builder]
 factory = "jupyter_packaging.npm_builder"
@@ -14,4 +22,9 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tool.check-manifest]
-ignore = ["jupyterlab_webrtc_docprovider/labextension/**", "yarn.lock", ".*", "package-lock.json"]
+ignore = [
+    ".*",
+    "jupyterlab_webrtc_docprovider/labextension/**",
+    "package-lock.json",
+    "yarn.lock",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,8 @@ ignore = [
     "package-lock.json",
     "yarn.lock",
 ]
+
+[tool.jupyter-releaser]
+skip = [
+    "check-links",  # TODO: restore after initial release
+]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ HERE = Path(__file__).parent.resolve()
 pkg_json = json.loads((HERE / "package.json").read_bytes())
 
 # The name of the project
-name = "jupyterlab_webrtc_docprovider"
+name = "jupyterlab-webrtc-docprovider"
 
 lab_path = (HERE / pkg_json["jupyterlab"]["outputDir"])
 


### PR DESCRIPTION
## References

- clean up issues found in #5

## Code changes

- generally user hyphenated name vs underscored name

## User-facing changes

- should align better with upstream URLs etc

## Backwards-incompatible changes

- n/a